### PR TITLE
Feature/cph dk flights parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /log/*
 !/log/.keep
 /tmp
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+gem 'nokogiri'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,7 @@ group :development do
   gem 'spring'
 end
 
+group :test do
+  gem 'webmock'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  nokogiri
   rails (= 4.2.5)
   rspec-rails (~> 3.4)
   sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -55,12 +56,15 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.2.3)
     i18n (0.7.0)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -131,6 +135,7 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -164,6 +169,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -186,6 +195,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,21 +1,7 @@
 class HomeController < ApplicationController
   def show
     render locals: {
-      departure_flights: departure_flights
+      departure_flights: AirportService.departure_flights
     }
-  end
-
-  private
-
-  def departure_flights
-    [OpenStruct.new({
-      scheduled_time: Time.now,
-      delayed_time: 5.minutes.from_now,
-      airline: 'JetBlue',
-      destination: 'America',
-      gate: '5G',
-      terminal: 'Terminal 3',
-      flight_status: 'Boarding'
-    })]
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,21 @@
 class HomeController < ApplicationController
   def show
+    render locals: {
+      departure_flights: departure_flights
+    }
+  end
+
+  private
+
+  def departure_flights
+    [OpenStruct.new({
+      scheduled_time: Time.now,
+      delayed_time: 5.minutes.from_now,
+      airline: 'JetBlue',
+      destination: 'America',
+      gate: '5G',
+      terminal: 'Terminal 3',
+      flight_status: 'Boarding'
+    })]
   end
 end

--- a/app/models/parsers/cph_airport_flights_parser.rb
+++ b/app/models/parsers/cph_airport_flights_parser.rb
@@ -1,0 +1,53 @@
+module Parsers
+  class CPHAirportFlightsParser
+    def self.parse_departure_flights(html)
+      new(Nokogiri::HTML(html)).parse_departure_flights
+    end
+
+    def initialize(html_doc)
+      @html_doc = html_doc
+    end
+
+    def parse_departure_flights
+      departure_flights = []
+      each_table_row do |table_row|
+        departure_flights << parse_flight_info(table_row)
+      end
+      departure_flights
+    end
+
+    private
+
+    attr_reader :html_doc
+
+    def parse_flight_info(table_row)
+      flight_info = {}
+      flight_info_attributes.each do |name, xpath|
+        flight_info[name] = xpath_text(table_row, xpath).strip
+      end
+      OpenStruct.new(flight_info)
+    end
+
+    def xpath_text(table_row, xpath)
+      table_row.at_xpath(xpath).try(:text) || ""
+    end
+
+    def flight_info_attributes
+      {
+        scheduled_time: 'td[@class="scheduled-time"]/span[1]',
+        delayed_time: 'td[@class="delayed-time"]',
+        airline: 'td[@class="airlines"]',
+        destination: 'td[@class="flight-destin"]/strong',
+        gate: 'td[@title="Gate"]',
+        terminal: 'td[contains(@class, "terminal")]',
+        flight_status: 'td/span[contains(@class, "flight-label")]'
+      }
+    end
+
+    def each_table_row(&block)
+      html_doc.xpath('//table[@class="info-table"]/tbody/tr').each do |tr|
+        yield tr
+      end
+    end
+  end
+end

--- a/app/services/airport_service.rb
+++ b/app/services/airport_service.rb
@@ -1,0 +1,34 @@
+class AirportService
+
+  def initialize(airport_website)
+    @website = airport_website
+  end
+
+  def self.departure_flights
+    new(CPHAirportWebsite.new).departure_flights
+  end
+
+  def departure_flights
+    html = http_client.get(website.flight_departures_url)
+    flights_parser.parse_departure_flights(html)
+  end
+
+  private
+
+  attr_reader :website
+
+  def http_client
+    HTTPClient
+  end
+
+  def flights_parser
+    Parsers::CPHAirportFlightsParser
+  end
+
+  # TODO: This could be in configuration
+  class CPHAirportWebsite
+    def flight_departures_url
+      "https://www.cph.dk/en/flight-info/departures1/"
+    end
+  end
+end

--- a/app/views/home/_flight.html.erb
+++ b/app/views/home/_flight.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td><%= flight.scheduled_time %></td>
+  <td><%= flight.delayed_time %></td>
+  <td><%= flight.airline %></td>
+  <td><%= flight.destination %></td>
+  <td><%= flight.gate %></td>
+  <td><%= flight.terminal %></td>
+  <td><%= flight.flight_status %></td>
+</tr>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,1 +1,18 @@
 Flights
+
+<table>
+  <thead>
+    <tr>
+      <th>Scheduled Time</th>
+      <th>Delayed Time</th>
+      <th>Airline</th>
+      <th>Flying To</th>
+      <th>Gate</th>
+      <th>Terminal</th>
+      <th>Flight Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'flight', collection: departure_flights %>
+  </tbody>
+</table>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,8 @@ module CphFlights
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Set the 'lib' directory to rails autoload path
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -1,0 +1,5 @@
+class HTTPClient
+  def self.get(url)
+    Net::HTTP.get(URI(url))
+  end
+end

--- a/spec/features/user_visits_homepage_spec.rb
+++ b/spec/features/user_visits_homepage_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 feature "User Visits Homepage" do
   context "for depature flights" do
     it "sees a list of expected departure flights" do
-      visit '/'
+      stub_request(:get, /cph.dk/).to_return(body: departures_html)
 
       home_page = Pages::Home.new
+
+      visit '/'
+
       expect(home_page).to have_departure_flights(expected_departure_flights)
     end
 
@@ -15,13 +18,19 @@ feature "User Visits Homepage" do
         "Rhodes, Greece - RHO  Rhodes International Airport"
       ]
     end
+
+
+    def departures_html
+      File.open(Dir.pwd + '/spec/fixtures/html/' + 'cph_departures_lite.html', 'rb').read
+    end
   end
 
-  context "for arrival flights" do
+  context "for arrival flights", :skip do
     it "sees a list of expected arrival flights" do
+      home_page = Pages::Home.new
+
       visit '/'
 
-      home_page = Pages::Home.new
       expect(home_page).to have_arrival_flights(expected_arrival_flights)
     end
 

--- a/spec/fixtures/html/cph_departures_lite.html
+++ b/spec/fixtures/html/cph_departures_lite.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<!--[if IE 7]>         <html class="no-js lt-ie10 lt-ie9 lt-ie8 nomobile has-background" lang="en" dir="ltr"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie10 lt-ie9 nomobile has-background" lang="en" dir="ltr"> <![endif]-->
+<!--[if IE 9]>         <html class="no-js lt-ie10 nomobile has-background" lang="en" dir="ltr"> <![endif]-->
+<!--[if gt IE 9]><!--> <html class="no-js nomobile has-background" lang="en" dir="ltr"> <!--<![endif]-->
+<head>
+
+	<title>Departures</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+	<meta name="format-detection" content="telephone=no" />
+	<meta name="application-name" content="Copenhagen Airports" />
+	<meta name="msapplication-tooltip" content="Start the Copenhagen Airports website" />
+	<meta name="msapplication-starturl" content="https://www.cph.dk/" />
+	<meta name="msapplication-TileImage" content="https://www.cph.dk/apple-touch-icon-144x144-precomposed.png" />
+	<meta name="msapplication-TileColor" content="#ad52cc" />
+	<meta name="SKYPE_TOOLBAR" content ="SKYPE_TOOLBAR_PARSER_COMPATIBLE" />
+
+  </head>
+
+<body class="search-page" id="cph">
+
+<table class="info-table">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>DelayedTime</th>
+                    <th>Airline</th>
+                        <th>To</th>
+                            <th class="right-aligned">Gate</th>
+                        <th class="right-aligned">Terminal</th>
+                    <th class="right-aligned">FlightStatus</th>
+                </tr>
+            </thead>
+            <tbody>
+                    <tr class="odd">
+                        <td class="scheduled-time">
+
+                            <span class="">12:10 AM</span>
+                            <span class="narrow-view-content"></span>
+                        </td>
+
+                        <td class="delayed-time">
+
+                        </td>
+
+                        <td class="airlines">Aeroflot</td>
+
+                        <td class="flight-destin">
+                            <strong class="destination">Moscow, Russian Federation - SVO  Sheremetyevo International Airport</strong>
+                            <span class="narrow-view-content">Aeroflot</span>
+                            <div class="flight-num sliding">
+                                            <span class="main-flight">SU2497</span>
+                                            <span>FI7210</span>
+                            </div>
+                        </td>
+
+                                <td class="right-aligned" title="Gate">C35</td>
+                            <td class="right-aligned terminal">T3</td>
+
+                        <td class="last right-aligned">
+                                <span class="flight-label closed">Closed</span>
+                        </td>
+                    </tr>
+                    <tr class="even">
+                        <td class="scheduled-time">
+
+                            <span class="">12:30 AM</span>
+                            <span class="narrow-view-content"></span>
+                        </td>
+
+                        <td class="delayed-time">
+
+                        </td>
+
+                        <td class="airlines">Thomas Cook Airlines</td>
+
+                        <td class="flight-destin">
+                            <strong class="destination">Rhodes, Greece - RHO  Rhodes International Airport</strong>
+                            <span class="narrow-view-content">Thomas Cook Airlines</span>
+                            <div class="flight-num ">
+                                    <span class="main-flight">DK357</span>
+                            </div>
+                        </td>
+
+                                <td class="right-aligned" title="Gate">B7</td>
+                            <td class="right-aligned terminal"></td>
+
+                        <td class="last right-aligned">
+								<button type="button" class="sms-btn" data-url="http://m.cph.dk/smsservice/assign.html?location=Rhodos&amp;date=16-06-2016&amp;flightno=DK357&amp;language=en&amp;type=departure">SMS</button>
+								<a href="/en/flight-info/app/" class="app-btn">APP</a>
+                        </td>
+                    </tr>
+                      </tr>
+            </tbody>
+        </table>
+        </body>
+        </html>

--- a/spec/models/parsers/cph_airport_flights_parser_spec.rb
+++ b/spec/models/parsers/cph_airport_flights_parser_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Parsers::CPHAirportFlightsParser do
+  describe ".parse_departure_flights" do
+    it "parses html text to expected array of hashes" do
+      parsed_array = described_class.parse_departure_flights(departures_html)
+
+      expect(parsed_array).to match(expected_array)
+    end
+
+    def departures_html
+      File.open(Dir.pwd + '/spec/fixtures/html/' + 'cph_departures_lite.html', 'rb').read
+    end
+
+    def expected_array
+      [
+        OpenStruct.new({
+          scheduled_time: "12:10 AM",
+          delayed_time: "",
+          airline: "Aeroflot",
+          destination: "Moscow, Russian Federation - SVO  Sheremetyevo International Airport",
+          gate: "C35",
+          terminal: 'T3',
+          flight_status: 'Closed'
+        }),
+        OpenStruct.new({
+          scheduled_time: "12:30 AM",
+          delayed_time: "",
+          airline: "Thomas Cook Airlines",
+          destination: "Rhodes, Greece - RHO  Rhodes International Airport",
+          gate: "B7",
+          terminal: '',
+          flight_status: ''
+        })
+      ]
+    end
+  end
+end

--- a/spec/services/airport_service_spec.rb
+++ b/spec/services/airport_service_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe AirportService do
+  describe ".departure_flights" do
+    it "returns an array of expected flights" do
+      expected_array = ["flights"]
+      allow(HTTPClient).to receive(:get)
+
+      allow(Parsers::CPHAirportFlightsParser).to receive(:parse_departure_flights)
+      .and_return(expected_array)
+
+      flights = AirportService.departure_flights
+
+      expect(flights).to eq expected_array
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.
 #
+
+require 'webmock/rspec'
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/pages/home_page.rb
+++ b/spec/support/pages/home_page.rb
@@ -3,9 +3,15 @@ module Pages
     include Capybara::DSL
 
     def has_departure_flights?(departure_flights)
+      departure_flights.map do |flight|
+        return false unless page.has_text?(flight)
+      end
     end
 
     def has_arrival_flights?(arrival_flights)
+      arrival_flights.map do |flight|
+        return false unless page.has_text?(flight)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR introduces the following classes to achieve the parsing of departure flights from the cph.dk website.
- `CPHAirportFlightsParser` class which takes an html and returns an array of `OpenStructs` representing the departure flights
- `AirportService` which represents an airport’s website (in this case only cph.dk) and
  returns departure flights

The data is also rendered on the frontpage
